### PR TITLE
allow copy as fallback solution when resolution is bad

### DIFF
--- a/src/video/ffmpeg/threaded_decoder.h
+++ b/src/video/ffmpeg/threaded_decoder.h
@@ -43,6 +43,8 @@ class FFMPEGThreadedDecoder : public ThreadedDecoderInterface {
     private:
         void WorkerThread();
         void ProcessFrame(AVFramePtr p, NDArray out_buf);
+        NDArray CopyToNDArray(AVFramePtr p);
+        NDArray AsNDArray(AVFramePtr p);
         // void FetcherThread(std::condition_variable& cv, FrameQueuePtr frame_queue);
         PacketQueuePtr pkt_queue_;
         FrameQueuePtr frame_queue_;

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -139,18 +139,18 @@ void VideoReader::SetVideoStream(int stream_nb) {
     }
 
     // adjust width to match cpu alignment
-    if (width_ % kCPUAlignment != 0) {
-        int new_width = ((width_ / kCPUAlignment) + 1) * kCPUAlignment;
-        int new_height = static_cast<int>(1.f * height_ / width_ * new_width);
-        LOG(WARNING) << "Video Reader width: " << width_
-            << " is not aligned with CPU alignment preference(" << kCPUAlignment << "),"
-            << " causing non-compact array with degraded performance."
-            << " Automatically round up resolution to: "
-            << new_width << " x " << new_height
-            << ".\nYou can set 'VideoReader(..., width=n*32)' to avoid warnings.";
-        width_ = new_width;
-        height_ = new_height;
-    }
+    // if (width_ % kCPUAlignment != 0) {
+    //     int new_width = ((width_ / kCPUAlignment) + 1) * kCPUAlignment;
+    //     int new_height = static_cast<int>(1.f * height_ / width_ * new_width);
+    //     LOG(WARNING) << "Video Reader width: " << width_
+    //         << " is not aligned with CPU alignment preference(" << kCPUAlignment << "),"
+    //         << " causing non-compact array with degraded performance."
+    //         << " Automatically round up resolution to: "
+    //         << new_width << " x " << new_height
+    //         << ".\nYou can set 'VideoReader(..., width=n*32)' to avoid warnings.";
+    //     width_ = new_width;
+    //     height_ = new_height;
+    // }
     ndarray_pool_ = NDArrayPool(32, {height_, width_, 3}, kUInt8, ctx_);
     decoder_->SetCodecContext(dec_ctx, width_, height_);
     IndexKeyframes();


### PR DESCRIPTION
No longer restrict resolution and printing warnings.
After this PR decord will not warn resolution not fit, instead it will use copy as a fallback solution.